### PR TITLE
Fix frontend output rendering for generated posts

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1339,7 +1339,7 @@ class APIManager {
             comprimento_texto: data.comprimento_texto || 'médio',
             incluir_cta: data.cta,
             incluir_hashtags: data.hashtags,
-            inclir_emojis: data.emojis,
+            incluir_emojis: data.emojis,
             keywords: data.keywords,
             max_tokens: parseInt(data.maxTokens) || 512,
             temperature: parseFloat(data.temperature) || 0.7
@@ -1408,8 +1408,14 @@ class App {
 
         try {
             const result = await this.apiManager.generate(data);
-            this.displayResult(result.content);
-            state.lastGeneratedContent = result.content;
+            const generatedContent = result.text || result.content;
+
+            if (!generatedContent) {
+                throw new Error('A resposta da API não contém nenhum texto para exibir.');
+            }
+
+            this.displayResult(generatedContent);
+            state.lastGeneratedContent = generatedContent;
             toast.success('Conteúdo gerado com sucesso!');
         } catch (error) {
             this.displayError(error.message);


### PR DESCRIPTION
## Summary
- correct the payload field name when sending the emoji flag to the API
- handle both `text` and `content` fields from the API response before rendering
- add validation to surface an error when the API does not return any text

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6977b067c832eb7c1addc161aedb1